### PR TITLE
Fix cargo-audit installation:

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile_jdk
+++ b/dockerfiles/ubuntu/Dockerfile_jdk
@@ -21,7 +21,7 @@ SHELL ["/bin/bash", "-c"]
 RUN set -euxo pipefail \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-transport-https apt-utils \
-      ca-certificates curl dirmngr gnupg2 jq pigz wget \
+      ca-certificates curl dirmngr git gnupg2 jq pigz wget \
     && if ! command -v gosu &> /dev/null; then \
       dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
       && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \

--- a/dockerfiles/ubuntu/Dockerfile_rust
+++ b/dockerfiles/ubuntu/Dockerfile_rust
@@ -26,7 +26,7 @@ SHELL ["/bin/bash", "-c"]
 RUN set -euxo pipefail \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils \
-      build-essential ca-certificates curl dirmngr gcc-mingw-w64-x86-64 gnupg2 jq \
+      build-essential ca-certificates curl dirmngr gcc-mingw-w64-x86-64 git gnupg2 jq \
       libssl-dev pigz pkg-config wget \
     && if ! command -v gosu &> /dev/null; then \
       dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
@@ -55,7 +55,11 @@ RUN set -euxo pipefail \
       echo 'linker = "x86_64-w64-mingw32-gcc"'; \
       echo 'ar = "x86_64-w64-mingw32-gcc-ar"'; \
     } | tee -a /{root,etc/skel}/.cargo/config > /dev/null \
-    && cargo install --version ${ARG_CARGO_AUDIT_VERSION} cargo-audit \
+    && git clone --single-branch --branch cargo-audit/v${CARGO_AUDIT_VERSION} https://github.com/rustsec/rustsec /root/rustsec \
+    && cd /root/rustsec/cargo-audit \
+    && cargo build --release \
+    && cd && cp -a /root/rustsec/target/release/cargo-audit /opt/rust/cargo/bin/cargo-audit \
+    && rm -rf /root/rustsec \
     && apt-get -y clean \
     && apt-get -y autoclean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/* \


### PR DESCRIPTION
The smartstring dependency of cargo audit changed it's
minimum supported version of Rust to 1.56.0. As "cargo install"
doesn't honor Cargo.lock there is no way to pin smartstring to
an older version using the install command/cargo packages.
Solved by building and installing cargo-audit from source
which does honor the committed Cargo.lock.