### PR TITLE
Preparing base image to use for ZkVerify pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - DOCKER_ORG=zencash
     - IMAGE_NAME=sc-ci-base
-    - GOSU_VERSION=1.16
+    - GOSU_VERSION=1.17
     - RUST_CROSS_TARGETS=x86_64-pc-windows-gnu
     - CARGO_AUDIT_VERSION_OLD_RUST=0.16.0
   jobs:
@@ -27,6 +27,11 @@ env:
     - BASE_IMAGE=ubuntu:jammy FLAVORS=rust-nightly COMBINE='rust-nightly;jdk-8,jdk-11,jdk-17'
     - BASE_IMAGE=ubuntu:jammy FLAVORS=rust-nightly-2021-04-25 COMBINE='rust-nightly-2021-04-25;jdk-8,jdk-11,jdk-17'
     - BASE_IMAGE=ubuntu:jammy FLAVORS=jdk-8,jdk-11,jdk-17
+    - BASE_IMAGE=ubuntu:noble FLAVORS=rust-1.51.0 COMBINE='rust-1.51.0;jdk-8,jdk-11,jdk-17'
+    - BASE_IMAGE=ubuntu:noble FLAVORS=rust-stable COMBINE='rust-stable;jdk-8,jdk-11,jdk-17'
+    - BASE_IMAGE=ubuntu:noble FLAVORS=rust-nightly COMBINE='rust-nightly;jdk-8,jdk-11,jdk-17'
+    - BASE_IMAGE=ubuntu:noble FLAVORS=rust-nightly-2021-04-25 COMBINE='rust-nightly-2021-04-25;jdk-8,jdk-11,jdk-17'
+    - BASE_IMAGE=ubuntu:noble FLAVORS=jdk-8,jdk-11,jdk-17
     - BASE_IMAGE=debian:buster FLAVORS=rust-1.51.0 COMBINE='rust-1.51.0;jdk-8,jdk-11,jdk-17'
     - BASE_IMAGE=debian:buster FLAVORS=rust-stable COMBINE='rust-stable;jdk-8,jdk-11,jdk-17'
     - BASE_IMAGE=debian:buster FLAVORS=rust-nightly COMBINE='rust-nightly;jdk-8,jdk-11,jdk-17'

--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ For all of these images versions from the following base images are being built:
 - `ubuntu:bionic`
 - `ubuntu:focal`
 - `ubuntu:jammy`
+- `ubuntu:noble`
 - `debian:buster`
 - `debian:bullseye`
 
 The images are tagged using the followig schema:
 ```
-zencash/sc-ci-base:{bionic,focal,jammy,buster,bullseye}_rust-{1.51.0,stable,nightly,nightly-2021-04-25}_{$(date +%Y%m%d),latest};
-zencash/sc-ci-base:{bionic,focal,jammy,buster,bullseye}_jdk-{8,11,17}_{$(date +%Y%m%d),latest};
-zencash/sc-ci-base:{bionic,focal,jammy,buster,bullseye}_rust-{1.51.0,stable,nightly,nightly-2021-04-25}_jdk-{8,11,17}_{$(date +%Y%m%d),latest};
+zencash/sc-ci-base:{bionic,focal,jammy,noble,buster,bullseye}_rust-{1.51.0,stable,nightly,nightly-2021-04-25}_{$(date +%Y%m%d),latest};
+zencash/sc-ci-base:{bionic,focal,jammy,noble,buster,bullseye}_jdk-{8,11,17}_{$(date +%Y%m%d),latest};
+zencash/sc-ci-base:{bionic,focal,jammy,noble,buster,bullseye}_rust-{1.51.0,stable,nightly,nightly-2021-04-25}_jdk-{8,11,17}_{$(date +%Y%m%d),latest};
 ```
 
 ### Currently available tags (only latest shown)
@@ -150,4 +151,23 @@ zencash/sc-ci-base:jammy_rust-stable_jdk-11_latest
 zencash/sc-ci-base:jammy_rust-stable_jdk-17_latest
 zencash/sc-ci-base:jammy_rust-stable_jdk-8_latest
 zencash/sc-ci-base:jammy_rust-stable_latest
+zencash/sc-ci-base:noble_jdk-11_latest
+zencash/sc-ci-base:noble_jdk-17_latest
+zencash/sc-ci-base:noble_jdk-8_latest
+zencash/sc-ci-base:noble_rust-1.51.0_jdk-11_latest
+zencash/sc-ci-base:noble_rust-1.51.0_jdk-17_latest
+zencash/sc-ci-base:noble_rust-1.51.0_jdk-8_latest
+zencash/sc-ci-base:noble_rust-1.51.0_latest
+zencash/sc-ci-base:noble_rust-nightly-2021-04-25_jdk-11_latest
+zencash/sc-ci-base:noble_rust-nightly-2021-04-25_jdk-17_latest
+zencash/sc-ci-base:noble_rust-nightly-2021-04-25_jdk-8_latest
+zencash/sc-ci-base:noble_rust-nightly-2021-04-25_latest
+zencash/sc-ci-base:noble_rust-nightly_jdk-11_latest
+zencash/sc-ci-base:noble_rust-nightly_jdk-17_latest
+zencash/sc-ci-base:noble_rust-nightly_jdk-8_latest
+zencash/sc-ci-base:noble_rust-nightly_latest
+zencash/sc-ci-base:noble_rust-stable_jdk-11_latest
+zencash/sc-ci-base:noble_rust-stable_jdk-17_latest
+zencash/sc-ci-base:noble_rust-stable_jdk-8_latest
+zencash/sc-ci-base:noble_rust-stable_latest
 ```

--- a/dockerfiles/ubuntu/Dockerfile_rust
+++ b/dockerfiles/ubuntu/Dockerfile_rust
@@ -28,7 +28,7 @@ RUN set -euxo pipefail \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils \
       build-essential ca-certificates curl dirmngr gcc-mingw-w64-x86-64 git gnupg2 jq \
-      libssl-dev pigz pkg-config wget \
+      libssl-dev pigz pkg-config protobuf-compiler wget \
     && if ! command -v gosu &> /dev/null; then \
       dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
       && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \


### PR DESCRIPTION
The idea is to use docker images for rust operations on zkVerify pipeline. It requires and extra apt package as well as adding noble flavor for future uses + gosu version updgrade