### PR TITLE
lld and cmake install by default

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile_rust
+++ b/dockerfiles/ubuntu/Dockerfile_rust
@@ -25,8 +25,8 @@ SHELL ["/bin/bash", "-c"]
 RUN set -euxo pipefail \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils \
-      build-essential ca-certificates curl dirmngr gcc-mingw-w64-x86-64 git gnupg2 jq \
-      libssl-dev pigz pkg-config protobuf-compiler llvm clang wget \
+      build-essential ca-certificates clang cmake curl dirmngr gcc-mingw-w64-x86-64 git gnupg2 jq \
+      libssl-dev lld llvm pigz pkg-config protobuf-compiler wget \
     && if ! command -v gosu &> /dev/null; then \
       dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
       && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \


### PR DESCRIPTION
lld and cmake install to avoid installing it everywhere under zkVerify and VFlow workflows