### PR TITLE
Refresh CI build matrix

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -32,17 +32,17 @@ jobs:
             flavor: rust-nightly
             combine: ""
 
-          - base-image: debian:bullseye
+          - base-image: ubuntu:resolute
             flavor: rust-stable
             combine: ""
-          - base-image: debian:bullseye
+          - base-image: ubuntu:resolute
             flavor: rust-nightly
             combine: ""
 
-          - base-image: debian:bookworm
+          - base-image: debian:trixie
             flavor: rust-stable
             combine: ""
-          - base-image: debian:bookworm
+          - base-image: debian:trixie
             flavor: rust-nightly
             combine: ""
     steps:


### PR DESCRIPTION
## Description

Refreshes the CI build matrix in [ci-base-docker](https://github.com/HorizenLabs/ci-base-docker) to track current LTS releases. Total build count remains 8 (4 base images × rust-stable + rust-nightly).

## Jira Ticket

N/A

## Changes

- Added `ubuntu:resolute` (Ubuntu 26.04 LTS)
- Added `debian:trixie` (Debian 13, current stable) as the single Debian flavor
- Removed `debian:bullseye` (Debian 11 — community LTS ends 2026-08-31)
- Removed `debian:bookworm` (Debian 12 — no active downstream consumers)

## Breaking Changes

Downstream consumers pinning `*_bullseye_*` or `*_bookworm_*` image tags must switch to `*_trixie_*`. Previously published images on Docker Hub are unaffected.

## Checks

- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified

## Additional information